### PR TITLE
Fix broken and changed links.

### DIFF
--- a/docs.cask.co/www/404.html
+++ b/docs.cask.co/www/404.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta content="Cask Data, Inc." name="author" />
     <meta content="Missing Page" name="description" />
-    <meta content="Copyright © 2015-2016 Cask Data, Inc." name="copyright" />
+    <meta content="Copyright © 2015-2017 Cask Data, Inc." name="copyright" />
     <meta name="robots" content="noindex" />
 
     <!-- Google Tag Manager start -->
@@ -22,8 +22,8 @@
 
     <title>Page Not Found (404 error message) &mdash; Cask Data Documentation</title>
     
-    <link rel="stylesheet" href="resources/cask.css" type="text/css" />
-    <link rel="stylesheet" href="resources/pygments.css" type="text/css" />
+    <link rel="stylesheet" href="/resources/cask.css" type="text/css" />
+    <link rel="stylesheet" href="/resources/pygments.css" type="text/css" />
 
     <script type="text/javascript">
       var DOCUMENTATION_OPTIONS = {
@@ -34,11 +34,11 @@
         HAS_SOURCE:  false
       };
     </script>
-    <script type="text/javascript" src="resources/jquery.js"></script>
-    <script type="text/javascript" src="resources/underscore.js"></script>
-    <script type="text/javascript" src="resources/doctools.js"></script>
-    <link rel="shortcut icon" href="resources/cask-favicon.ico"/>
-    <script type="text/javascript" src="resources/redirect-page.js"></script>
+    <script type="text/javascript" src="/resources/jquery.js"></script>
+    <script type="text/javascript" src="/resources/underscore.js"></script>
+    <script type="text/javascript" src="/resources/doctools.js"></script>
+    <link rel="shortcut icon" href="/resources/cask-favicon.ico"/>
+    <script type="text/javascript" src="/resources/redirect-page.js"></script>
   </head>
   <body role="document">
     <!-- Google Tag Manager (noscript) -->
@@ -58,7 +58,7 @@
           <div class="body" role="main">
             <div class="section" id="page-not-found-404-error-message">
             
-<img class="align-center" id="id1" src="resources/cask_404_75pc.png" height="428" width="720"/>
+<img class="align-center" id="id1" src="/resources/cask_404_75pc.png" height="428" width="720"/>
 
 <h1>Page Not Found (404 error message)</h1>
 <p>Unfortunately, whatever you were looking for, we can&#8217;t locate.</p>
@@ -66,10 +66,9 @@
 <p class="rubric">Perhaps you were trying to reach...</p>
 
 <ul class="simple">
-<li><a class="reference external" href="cdap/index.html"><strong>Cask Data Application Platform (CDAP)</strong></a></li>
-<li><a class="reference external" href="coopr/index.html"><strong>Coopr</strong></a></li>
-<li><a class="reference external" href="tigon/index.html"><strong>Tigon</strong></a></li>
-<li><a class="reference external" href="collateral/current"><strong>Collateral: Datasheets</strong></a></li>
+<li><a class="reference external" href="/cdap/index.html"><strong>Cask Data Application Platform (CDAP)</strong></a></li>
+<li><a class="reference external" href="/coopr/index.html"><strong>Coopr</strong></a></li>
+<li><a class="reference external" href="/tigon/index.html"><strong>Tigon</strong></a></li>
 </ul>
 
 <p class="rubric">Try the Homepage</p>
@@ -109,12 +108,11 @@ Visit a product page to look there.</p>
 <div class="sphinxsidebar" role="navigation" aria-label="main navigation">
   <div class="sphinxsidebarwrapper">
     <div role="note" aria-label="manuals links">
-      <h3><a href="index.html">Cask Documentation</a></h3>
+      <h3><a href="/index.html">Cask Documentation</a></h3>
       <ul class="this-page-menu">
-        <li><a href="cdap/index.html" rel="nofollow">Cask Data Application Platform (CDAP)</a></li>
-        <li><a href="coopr/index.html" rel="nofollow">Coopr</a></li>
-        <li><a href="tigon/index.html" rel="nofollow">Tigon</a></li>
-        <li><a href="collateral/current/index.html" rel="nofollow">Collateral: Datasheets</a></li>
+        <li><a href="/cdap/index.html" rel="nofollow">Cask Data Application Platform (CDAP)</a></li>
+        <li><a href="/coopr/index.html" rel="nofollow">Coopr</a></li>
+        <li><a href="/tigon/index.html" rel="nofollow">Tigon</a></li>
       </ul>
     </div>
     
@@ -139,7 +137,7 @@ Visit a product page to look there.</p>
     <ul class="this-page-menu">
       <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
-      <li><a href="http://cdap.io/" rel="nofollow">CDAP (cdap.io)</a></li>
+      <li><a href="http://cask.co/products/cdap/" rel="nofollow">CDAP (cask.co/products/cdap)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>
       <li><a href="http://tigon.io/" rel="nofollow">Tigon (tigon.io)</a></li>
     </ul>

--- a/docs.cask.co/www/cdap/index.html
+++ b/docs.cask.co/www/cdap/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta content="Cask Data, Inc." name="author" />
     <meta content="Introduction to the Cask Data Application Platform" name="description" />
-    <meta content="Copyright © 2015-2016 Cask Data, Inc." name="copyright" />
+    <meta content="Copyright © 2015-2017 Cask Data, Inc." name="copyright" />
 
     <!-- Google Tag Manager start -->
     <script>dataLayer = [];</script>
@@ -102,7 +102,7 @@ on the product, and will receive all JIRA notifications.</p>
 <script type="text/javascript" src="../resources/replace-table-of-contents.js"></script>
 
 <!--
-  Copyright © 2015-2016 Cask Data, Inc.
+  Copyright © 2015-2017 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -137,7 +137,7 @@ on the product, and will receive all JIRA notifications.</p>
     <ul class="this-page-menu">
       <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
-      <li><a href="http://cdap.io/" rel="nofollow">CDAP (cdap.io)</a></li>
+      <li><a href="http://cask.co/products/cdap/" rel="nofollow">CDAP (cask.co/products/cdap)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>
       <li><a href="http://tigon.io/" rel="nofollow">Tigon (tigon.io)</a></li>
     </ul>

--- a/docs.cask.co/www/index.html
+++ b/docs.cask.co/www/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
     <meta content="Cask Data, Inc." name="author" />
     <meta content="Cask Data Documentation" name="description" />
-    <meta content="Copyright © 2015-2016 Cask Data, Inc." name="copyright" />
+    <meta content="Copyright © 2015-2017 Cask Data, Inc." name="copyright" />
     
     <!-- Google Tag Manager start -->
     <script>dataLayer = [];</script>
@@ -203,7 +203,7 @@ img.centeredImage {
 </div>
 
 <!--
-  Copyright © 2015-2016 Cask Data, Inc.
+  Copyright © 2015-2017 Cask Data, Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License"); you may not
   use this file except in compliance with the License. You may obtain a copy of
@@ -223,7 +223,7 @@ img.centeredImage {
     <ul class="this-page-menu">
       <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
-      <li><a href="http://cdap.io/" rel="nofollow">CDAP (cdap.io)</a></li>
+      <li><a href="http://cask.co/products/cdap/" rel="nofollow">CDAP (cask.co/products/cdap)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>
       <li><a href="http://tigon.io/" rel="nofollow">Tigon (tigon.io)</a></li>
     </ul>

--- a/docs.cask.co/www/resources/replace-table-of-contents.js
+++ b/docs.cask.co/www/resources/replace-table-of-contents.js
@@ -4,7 +4,7 @@
  *
  * JavaScript for replacing the table of contents with another one 
  *
- * :copyright: © Copyright 2015 Cask Data, Inc.
+ * :copyright: © Copyright 2015-2017 Cask Data, Inc.
  * :license: Apache License, Version 2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not
@@ -39,6 +39,9 @@
       });
       $("#loadedCurrentReleaseMenu").find("h3").each(function() {
           this.innerHTML = this.innerHTML + " (Current&nbsp;Release)";
+          $(this).find("a").each(function() {
+              this.href = "current/en/" + $(this).attr("href");
+          });
       });
   });
 })();


### PR DESCRIPTION
A number of links have broken or have been changed on the `docs.cask.co` website.

Some need a leading slash to work properly on Amazon S3. 
Some have just gone as we have retired `cdap.io`.
It also fixes a link on the main CDAP documentation page so that it links to the current release (instead of itself).

For example: this page is broken; it should be our 404 page, but the links are bad so that the CSS and image doesn't load: http://docs.cask.co/cdap/current/en/junk.html