### PR TITLE
Fix error in documentation menu

### DIFF
--- a/docs.cask.co/scripts/builder.py
+++ b/docs.cask.co/scripts/builder.py
@@ -170,7 +170,8 @@ def _build_timeline():
         if len(older[i]) > 3:
             included = older[i].pop()
             older[i].append(style)
-            older[i].append(included)
+            if not bool(included):
+                older[i].append(included)
         else:
             older[i].append(style)
         


### PR DESCRIPTION
Fix error in documentation menu: only append flag if the flag is to _not_ include in the menu.