### PR TITLE
Update the Google Search Engines used for release 4.0.1.

### DIFF
--- a/docs.cask.co/configs/cdap.txt
+++ b/docs.cask.co/configs/cdap.txt
@@ -25,7 +25,7 @@
 # older
 #
 # Fields:
-# directory, label, date released YYYY-MM-DD, included-in-menu (1 = True, 0 = False), Google Custom Search Engine ID
+# directory, label, date released YYYY-MM-DD, included-in-menu (1 = True, 0 = False), GCSEI (Google Custom Search Engine ID)
 #
 # Lines like these are comments
 
@@ -36,10 +36,11 @@ development
 4.2.0-SNAPSHOT, 4.2.0, '', 1, 002451258715120217843:6jye64lrjyq
 
 current
+# GCSEI for current          002451258715120217843:nkzqh6x__gy
 4.1.0, 4.1.0, 2017-02-26, 1, 002451258715120217843:v_9tcw7mwb0
 
 older
-4.0.1, 4.0.1, 2017-01-24, 1, 002451258715120217843:nkzqh6x__gy
+4.0.1, 4.0.1, 2017-01-24, 1, 002451258715120217843:dzq7nukehdo
 4.0.0, 4.0.0, 2016-12-20, 0, 002451258715120217843:ghzueoxyboy
 3.6.0, 3.6.0, 2016-10-05
 3.5.3, 3.5.3, 2017-01-23


### PR DESCRIPTION
- Added a comment about which one is used for "current", as "current" doesn't have an entry
- the 4.0.1 release now has its own custom search engine (set by the code `002451258715120217843:dzq7nukehdo`) and is being changed to use that one, rather than the "current" custom search engine.
- The codes consist of two parts: our account plus the ID of the individual search engine.
- Each search engine points at a different part of the documentation, such as

  - 4.1.0 -> http://docs.cask.co/cdap/4.1.0/*
  - 4.0.1 -> http://docs.cask.co/cdap/4.0.1/*
  - current -> http://docs.cask.co/cdap/current/*
