### PR TITLE
Remove protocol on docs.cask.co links

### DIFF
--- a/docs.cask.co/configs/cdap.txt
+++ b/docs.cask.co/configs/cdap.txt
@@ -30,7 +30,7 @@
 # Lines like these are comments
 
 versions
-http://docs.cask.co/cdap/json-versions.js
+//docs.cask.co/cdap/json-versions.js
 
 development
 4.2.0-SNAPSHOT, 4.2.0, '', 1, 002451258715120217843:6jye64lrjyq

--- a/docs.cask.co/configs/coopr.txt
+++ b/docs.cask.co/configs/coopr.txt
@@ -30,7 +30,7 @@
 # Lines like these are comments
 
 versions
-http://docs.cask.co/coopr/json-versions.js
+//docs.cask.co/coopr/json-versions.js
 
 development
 # None currently

--- a/docs.cask.co/configs/tigon.txt
+++ b/docs.cask.co/configs/tigon.txt
@@ -30,7 +30,7 @@
 # Lines like these are comments
 
 versions
-http://docs.cask.co/tigon/json-versions.js
+//docs.cask.co/tigon/json-versions.js
 
 development
 # None currently

--- a/docs.cask.co/scripts/builder.py
+++ b/docs.cask.co/scripts/builder.py
@@ -443,7 +443,7 @@ def write_sitemap_index_xml(target, type):
         
         sitemap_urls = ''
         for version in sitemap:
-            sitemap_urls += SITEMAP_TEMPLATE % ("http://docs.cask.co/%s/%s/sitemap.xml" % (type, version))
+            sitemap_urls += SITEMAP_TEMPLATE % ("//docs.cask.co/%s/%s/sitemap.xml" % (type, version))
         sitemap_xml = SITEMAP_INDEX_XML_TEMPLATE % sitemap_urls
 
         f.write(sitemap_xml)

--- a/docs.cask.co/www/404.html
+++ b/docs.cask.co/www/404.html
@@ -135,7 +135,7 @@ Visit a product page to look there.</p>
 <div role="note" aria-label="other links">
     <h3>Cask Sites</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
+      <li><a href="//docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
       <li><a href="http://cask.co/products/cdap/" rel="nofollow">CDAP (cask.co/products/cdap)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>

--- a/docs.cask.co/www/cdap/current/en/_static/version-menu.js
+++ b/docs.cask.co/www/cdap/current/en/_static/version-menu.js
@@ -19,7 +19,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  * 
- * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
+ * Requires a JSONP file at docs.cask.co/cdap/json-versions.js in the format:
  * 
  * versionscallback({'development': [['3.5.0-SNAPSHOT', '3.5.0']], 'current': ['3.4.1', '3.4.1', '2016-05-12'], 'timeline': [['0', '3.4.0', '2016-04-29', ' (100 days)'], ['1', '3.4.1', '2016-05-12', ' (13 days)'], ['0', '3.3.0', '2016-01-20', ' (119 days)'], ['1', '3.3.1', '2016-02-19', ' (30 days)'], ['1', '3.3.2', '2016-03-07', ' (17 days)'], ['1', '3.3.3', '2016-04-15', ' (39 days)'], ['1', '3.3.4', '2016-05-19', ' (34 days)'], ['0', '3.2.0', '2015-09-23', ' (51 days)'], ['1', '3.2.1', '2015-10-21', ' (28 days)'], ... ['2.6.0', '2.6.0', '2015-01-10', '']]});
  * 
@@ -30,7 +30,7 @@
  */
 
 (function() {
-  var versionsURL = 'http://docs.cask.co/cdap/';
+  var versionsURL = '//docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
     return versionsURL + dir + '/en/';

--- a/docs.cask.co/www/cdap/current/en/index.html
+++ b/docs.cask.co/www/cdap/current/en/index.html
@@ -61,7 +61,7 @@
              accesskey="P">Previous</a> |</li>
         
         <script type="text/javascript" src="_static/version-menu.js"></script>      
-<!--    <script src="http://docs.cask.co/cdap/json-versions.js"/></script> -->
+<!--    <script src="//docs.cask.co/cdap/json-versions.js"/></script> -->
   		  <script src="../../json-versions.js"/></script>
       
         <script>window.setVersion('2.7.1');</script>
@@ -222,7 +222,7 @@ on the installation, monitoring and diagnosing fully distributed CDAP in a Hadoo
   <div role="note" aria-label="downloads links">
     <h3>Downloads</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/cdap/2.7.1/cdap-docs-2.7.1-web.zip"
+      <li><a href="//docs.cask.co/cdap/2.7.1/cdap-docs-2.7.1-web.zip"
             rel="nofollow">Zip Archive of CDAP Documentation</a></li>
     </ul>
    </div>

--- a/docs.cask.co/www/cdap/examples/index.html
+++ b/docs.cask.co/www/cdap/examples/index.html
@@ -1,7 +1,7 @@
 <HTML><BODY BGCOLOR="#FFFFFF">
 
 <HEAD><TITLE>CDAP Examples</TITLE>
-<META HTTP-EQUIV="refresh" CONTENT="0; URL=http://docs.cask.co/cdap/current/en/examples-manual/examples/index.html">
+<META HTTP-EQUIV="refresh" CONTENT="0; URL=//docs.cask.co/cdap/current/en/examples-manual/examples/index.html">
 </HEAD>
 
 <BODY></BODY></HTML>

--- a/docs.cask.co/www/cdap/index.html
+++ b/docs.cask.co/www/cdap/index.html
@@ -135,7 +135,7 @@ on the product, and will receive all JIRA notifications.</p>
 <div role="note" aria-label="other links">
     <h3>Cask Sites</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
+      <li><a href="//docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
       <li><a href="http://cask.co/products/cdap/" rel="nofollow">CDAP (cask.co/products/cdap)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>

--- a/docs.cask.co/www/collateral/current/index.html
+++ b/docs.cask.co/www/collateral/current/index.html
@@ -173,7 +173,7 @@ img.centeredImage {
 <div role="note" aria-label="other links">
     <h3>Cask Sites</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
+      <li><a href="//docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
       <li><a href="http://cdap.io/" rel="nofollow">CDAP (cdap.io)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>

--- a/docs.cask.co/www/coopr/current/en/_static/version-menu.js
+++ b/docs.cask.co/www/coopr/current/en/_static/version-menu.js
@@ -19,7 +19,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  * 
- * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
+ * Requires a JSONP file at docs.cask.co/cdap/json-versions.js in the format:
  * 
  * versionscallback({'development': [['3.5.0-SNAPSHOT', '3.5.0']], 'current': ['3.4.1', '3.4.1', '2016-05-12'], 'timeline': [['0', '3.4.0', '2016-04-29', ' (100 days)'], ['1', '3.4.1', '2016-05-12', ' (13 days)'], ['0', '3.3.0', '2016-01-20', ' (119 days)'], ['1', '3.3.1', '2016-02-19', ' (30 days)'], ['1', '3.3.2', '2016-03-07', ' (17 days)'], ['1', '3.3.3', '2016-04-15', ' (39 days)'], ['1', '3.3.4', '2016-05-19', ' (34 days)'], ['0', '3.2.0', '2015-09-23', ' (51 days)'], ['1', '3.2.1', '2015-10-21', ' (28 days)'], ... ['2.6.0', '2.6.0', '2015-01-10', '']]});
  * 
@@ -30,7 +30,7 @@
  */
 
 (function() {
-  var versionsURL = 'http://docs.cask.co/cdap/';
+  var versionsURL = '//docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
     return versionsURL + dir + '/en/';

--- a/docs.cask.co/www/coopr/current/en/index.html
+++ b/docs.cask.co/www/coopr/current/en/index.html
@@ -53,7 +53,7 @@
              accesskey="N">Next</a> |</li>
         
         <script type="text/javascript" src="_static/version-menu.js"></script>
-<!--    <script src="http://docs.cask.co/coopr/json-versions.js"/></script> -->
+<!--    <script src="//docs.cask.co/coopr/json-versions.js"/></script> -->
   		  <script src="../../json-versions.js"/></script>
         <script>window.setVersion('0.9.9-SNAPSHOT');</script>
        
@@ -248,7 +248,7 @@ and tell us what you think.</p>
   <div role="note" aria-label="downloads links">
     <h3>Downloads</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/coopr/0.9.9-SNAPSHOT/coopr-docs-0.9.9-SNAPSHOT-web.zip"
+      <li><a href="//docs.cask.co/coopr/0.9.9-SNAPSHOT/coopr-docs-0.9.9-SNAPSHOT-web.zip"
             rel="nofollow">Zip Archive of Coopr Documentation</a></li>
     </ul>
    </div>

--- a/docs.cask.co/www/coopr/index.html
+++ b/docs.cask.co/www/coopr/index.html
@@ -128,7 +128,7 @@ This mailing list will also receive all JIRA and GitHub notifications.</p>
 <div role="note" aria-label="other links">
     <h3>Cask Sites</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
+      <li><a href="//docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
       <li><a href="http://cdap.io/" rel="nofollow">CDAP (cdap.io)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>

--- a/docs.cask.co/www/index.html
+++ b/docs.cask.co/www/index.html
@@ -221,7 +221,7 @@ img.centeredImage {
 <div role="note" aria-label="other links">
     <h3>Cask Sites</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
+      <li><a href="//docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
       <li><a href="http://cask.co/products/cdap/" rel="nofollow">CDAP (cask.co/products/cdap)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>

--- a/docs.cask.co/www/resources/redirect-page.js
+++ b/docs.cask.co/www/resources/redirect-page.js
@@ -25,7 +25,7 @@
 
 (function() {
   var products = new Array( TYPE_ARRAY );
-  var origin = window.location.origin;     // "http://docs.cask.co"
+  var origin = window.location.origin;     // "//docs.cask.co"
   var pathname = window.location.pathname; // "/cdap/3.6.0/en/test.html"
   if (pathname[0] == '/') {
     pathname = pathname.substr(1);

--- a/docs.cask.co/www/robots.txt
+++ b/docs.cask.co/www/robots.txt
@@ -2,4 +2,4 @@ User-agent: *
 Disallow: /training/
 Disallow: /tutorial/
 
-Sitemap: http://docs.cask.co/sitemap_index.xml
+Sitemap: /sitemap_index.xml

--- a/docs.cask.co/www/sitemap_index.xml
+++ b/docs.cask.co/www/sitemap_index.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
    <sitemap>
-      <loc>http://docs.cask.co/sitemap_cdap_index.xml</loc>
+      <loc>https://docs.cask.co/sitemap_cdap_index.xml</loc>
    </sitemap>
 
    <sitemap>
-      <loc>http://docs.cask.co/sitemap_coopr_index.xml</loc>
+      <loc>https://docs.cask.co/sitemap_coopr_index.xml</loc>
    </sitemap>
 
    <sitemap>
-      <loc>http://docs.cask.co/sitemap_tigon_index.xml</loc>
+      <loc>https://docs.cask.co/sitemap_tigon_index.xml</loc>
    </sitemap>
 </sitemapindex>

--- a/docs.cask.co/www/tigon/current/en/_static/version-menu.js
+++ b/docs.cask.co/www/tigon/current/en/_static/version-menu.js
@@ -19,7 +19,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  * 
- * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
+ * Requires a JSONP file at docs.cask.co/cdap/json-versions.js in the format:
  * 
  * versionscallback({'development': [['3.5.0-SNAPSHOT', '3.5.0']], 'current': ['3.4.1', '3.4.1', '2016-05-12'], 'timeline': [['0', '3.4.0', '2016-04-29', ' (100 days)'], ['1', '3.4.1', '2016-05-12', ' (13 days)'], ['0', '3.3.0', '2016-01-20', ' (119 days)'], ['1', '3.3.1', '2016-02-19', ' (30 days)'], ['1', '3.3.2', '2016-03-07', ' (17 days)'], ['1', '3.3.3', '2016-04-15', ' (39 days)'], ['1', '3.3.4', '2016-05-19', ' (34 days)'], ['0', '3.2.0', '2015-09-23', ' (51 days)'], ['1', '3.2.1', '2015-10-21', ' (28 days)'], ... ['2.6.0', '2.6.0', '2015-01-10', '']]});
  * 
@@ -30,7 +30,7 @@
  */
 
 (function() {
-  var versionsURL = 'http://docs.cask.co/cdap/';
+  var versionsURL = '//docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
     return versionsURL + dir + '/en/';

--- a/docs.cask.co/www/tigon/index.html
+++ b/docs.cask.co/www/tigon/index.html
@@ -131,7 +131,7 @@ notifications.</p>
 <div role="note" aria-label="other links">
     <h3>Cask Sites</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
+      <li><a href="//docs.cask.co/" rel="nofollow"><strong>Cask Documentation</strong> (docs.cask.co)</a></li>
       <li><a href="http://cask.co/" rel="nofollow">Cask (cask.co)</a></li>
       <li><a href="http://cdap.io/" rel="nofollow">CDAP (cdap.io)</a></li>
       <li><a href="http://coopr.io/" rel="nofollow">Coopr (coopr.io)</a></li>

--- a/docs.cask.co/www_develop/cdap/2.7.1/en/_static/version-menu.js
+++ b/docs.cask.co/www_develop/cdap/2.7.1/en/_static/version-menu.js
@@ -19,7 +19,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  * 
- * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
+ * Requires a JSONP file at docs.cask.co/cdap/json-versions.js in the format:
  * 
  * versionscallback({'development': [['3.5.0-SNAPSHOT', '3.5.0']], 'current': ['3.4.1', '3.4.1', '2016-05-12'], 'timeline': [['0', '3.4.0', '2016-04-29', ' (100 days)'], ['1', '3.4.1', '2016-05-12', ' (13 days)'], ['0', '3.3.0', '2016-01-20', ' (119 days)'], ['1', '3.3.1', '2016-02-19', ' (30 days)'], ['1', '3.3.2', '2016-03-07', ' (17 days)'], ['1', '3.3.3', '2016-04-15', ' (39 days)'], ['1', '3.3.4', '2016-05-19', ' (34 days)'], ['0', '3.2.0', '2015-09-23', ' (51 days)'], ['1', '3.2.1', '2015-10-21', ' (28 days)'], ... ['2.6.0', '2.6.0', '2015-01-10', '']]});
  * 
@@ -30,7 +30,7 @@
  */
 
 (function() {
-  var versionsURL = 'http://docs.cask.co/cdap/';
+  var versionsURL = '//docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
     return versionsURL + dir + '/en/';

--- a/docs.cask.co/www_develop/cdap/2.7.1/en/index.html
+++ b/docs.cask.co/www_develop/cdap/2.7.1/en/index.html
@@ -61,7 +61,7 @@
              accesskey="P">Previous</a> |</li>
         
         <script type="text/javascript" src="_static/version-menu.js"></script>      
-<!--    <script src="http://docs.cask.co/cdap/json-versions.js"/></script> -->
+<!--    <script src="//docs.cask.co/cdap/json-versions.js"/></script> -->
   		  <script src="../../json-versions.js"/></script>
       
         <script>window.setVersion('2.7.1');</script>
@@ -222,7 +222,7 @@ on the installation, monitoring and diagnosing fully distributed CDAP in a Hadoo
   <div role="note" aria-label="downloads links">
     <h3>Downloads</h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/cdap/2.7.1/cdap-docs-2.7.1-web.zip"
+      <li><a href="//docs.cask.co/cdap/2.7.1/cdap-docs-2.7.1-web.zip"
             rel="nofollow">Zip Archive of CDAP Documentation</a></li>
     </ul>
    </div>

--- a/docs.cask.co/www_develop/cdap/4.1.0-SNAPSHOT/en/404.html
+++ b/docs.cask.co/www_develop/cdap/4.1.0-SNAPSHOT/en/404.html
@@ -24,7 +24,7 @@
     <meta name="git_timestamp" content="2017-02-22 09:20:52 -0800">
     <title>Page Not Found (404 error message) &mdash; Cask Data Application Platform 4.1.0-SNAPSHOT Documentation</title>
 
-    <link rel="canonical" href="http://docs.cask.co/cdap/4.1.0-SNAPSHOT/en/404.html">
+    <link rel="canonical" href="//docs.cask.co/cdap/4.1.0-SNAPSHOT/en/404.html">
 
     
     <link rel="stylesheet" href="/cdap/4.1.0-SNAPSHOT/en/_static/cdap.css" type="text/css" />
@@ -66,7 +66,7 @@
              accesskey="I">Index</a></li>
         
         <script type="text/javascript" src="/cdap/4.1.0-SNAPSHOT/en/_static/version-menu.js"></script>
-        <script src="http://docs.cask.co/cdap/json-versions.js"/></script>
+        <script src="//docs.cask.co/cdap/json-versions.js"/></script>
         <script>window.setVersion('4.1.0-SNAPSHOT');</script>
        
         <li><a href="/cdap/4.1.0-SNAPSHOT/en/table-of-contents.html">CDAP Documentation v4.1.0</a> &raquo;</li> 
@@ -162,19 +162,19 @@ the result list.</p>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script>
   <div role="note" aria-label="downloads links">
-    <h3><a href="http://docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
+    <h3><a href="//docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
             rel="nofollow">Download</a></h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
+      <li><a href="//docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
             rel="nofollow">Zip Archive of CDAP Documentation</a></li>
     </ul>
    </div>
 <div role="note" aria-label="other links">
-    <h3><a href="http://docs.cask.co/" target="_blank">Documentation</a></h3>
+    <h3><a href="//docs.cask.co/" target="_blank">Documentation</a></h3>
     <ul class="this-page-menu">
-        <li><a href="http://docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
-        <li><a href="http://docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
-        <li><a href="http://docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
+        <li><a href="//docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
+        <li><a href="//docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
+        <li><a href="//docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
     </ul>
 </div>
         </div>

--- a/docs.cask.co/www_develop/cdap/4.1.0-SNAPSHOT/en/_static/version-menu.js
+++ b/docs.cask.co/www_develop/cdap/4.1.0-SNAPSHOT/en/_static/version-menu.js
@@ -19,7 +19,7 @@
  * License for the specific language governing permissions and limitations under
  * the License.
  * 
- * Requires a JSONP file at http://docs.cask.co/cdap/json-versions.js in the format:
+ * Requires a JSONP file at docs.cask.co/cdap/json-versions.js in the format:
  * 
  * versionscallback({
  *  'development': [['3.5.0-SNAPSHOT', '3.5.0', '', '1']], 
@@ -45,7 +45,7 @@
  */
 
 (function() {
-  var versionsURL = 'http://docs.cask.co/cdap/';
+  var versionsURL = '//docs.cask.co/cdap/';
   var versionID = 'select-version';
   var buildURL = (function(dir){
     return versionsURL + dir + '/en/';

--- a/docs.cask.co/www_develop/cdap/4.1.0-SNAPSHOT/en/index.html
+++ b/docs.cask.co/www_develop/cdap/4.1.0-SNAPSHOT/en/index.html
@@ -24,7 +24,7 @@
     <meta name="git_timestamp" content="2017-02-22 09:20:52 -0800">
     <title>CDAP Documentation v4.1.0 &mdash; Cask Data Application Platform 4.1.0-SNAPSHOT Documentation</title>
 
-    <link rel="canonical" href="http://docs.cask.co/cdap/4.1.0-SNAPSHOT/en/index.html">
+    <link rel="canonical" href="//docs.cask.co/cdap/4.1.0-SNAPSHOT/en/index.html">
 
     
     <link rel="stylesheet" href="_static/cdap.css" type="text/css" />
@@ -73,7 +73,7 @@
              accesskey="P">Previous</a> |</li>
         
         <script type="text/javascript" src="_static/version-menu.js"></script>
-        <script src="http://docs.cask.co/cdap/json-versions.js"/></script>
+        <script src="//docs.cask.co/cdap/json-versions.js"/></script>
         <script>window.setVersion('4.1.0-SNAPSHOT');</script>
        
         <li><a href="table-of-contents.html">CDAP Documentation v4.1.0</a> &raquo;</li> 
@@ -251,19 +251,19 @@ bridging CDAP Metadata with Cloudera's data management tool, Navigator</li>
 </div>
 <script type="text/javascript">$('#searchbox').show(0);</script>
   <div role="note" aria-label="downloads links">
-    <h3><a href="http://docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
+    <h3><a href="//docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
             rel="nofollow">Download</a></h3>
     <ul class="this-page-menu">
-      <li><a href="http://docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
+      <li><a href="//docs.cask.co/cdap/4.1.0-SNAPSHOT/cdap-docs-4.1.0-SNAPSHOT-web.zip"
             rel="nofollow">Zip Archive of CDAP Documentation</a></li>
     </ul>
    </div>
 <div role="note" aria-label="other links">
-    <h3><a href="http://docs.cask.co/" target="_blank">Documentation</a></h3>
+    <h3><a href="//docs.cask.co/" target="_blank">Documentation</a></h3>
     <ul class="this-page-menu">
-        <li><a href="http://docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
-        <li><a href="http://docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
-        <li><a href="http://docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
+        <li><a href="//docs.cask.co/cdap/index.html" target="_blank">CDAP</a></li>
+        <li><a href="//docs.cask.co/coopr/index.html" target="_blank">Coopr</a></li>
+        <li><a href="//docs.cask.co/tigon/index.html" target="_blank">Tigon</a></li>
     </ul>
 </div>
         </div>


### PR DESCRIPTION
The only exception is the sitemap stuff, which I switched to SSL, since they don't ever load any scripts, they won't hit any cross-protocol security issues.